### PR TITLE
PSM-1497 Add configurable noValidate argument to all docker-registry commands

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-1
+version: 2.2.12-picnic-2
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/_helpers.tpl
+++ b/charts/spinnaker/templates/_helpers.tpl
@@ -83,7 +83,7 @@ Create name of kubeconfig file to use when setting up kubernetes provider
 {{- end }}
 
 {{/*
-Create global template to skip Docker registry enabling validation iff there
+Create a template to skip global Docker registry enabling validation iff there
 is at least one registry configured to skip this validation.
 */}}
 {{- define "skipDockerRegistryEnablingValidation" -}}

--- a/charts/spinnaker/templates/_helpers.tpl
+++ b/charts/spinnaker/templates/_helpers.tpl
@@ -83,8 +83,8 @@ Create name of kubeconfig file to use when setting up kubernetes provider
 {{- end }}
 
 {{/*
-Create global Docker registry configuration validation skip template to
-include iff there is at least one registry configured to skip this validation.
+Create global template to skip Docker registry enabling validation iff there
+is at least one registry configured to skip this validation.
 */}}
 {{- define "skipDockerRegistryEnablingValidation" -}}
 {{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}true{{ end }}{{ end }}

--- a/charts/spinnaker/templates/_helpers.tpl
+++ b/charts/spinnaker/templates/_helpers.tpl
@@ -81,3 +81,11 @@ Create name of kubeconfig file to use when setting up kubernetes provider
 {{- printf "/opt/kube/%s" .Values.kubeConfig.secretKey  | toString -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Create global Docker registry configuration validation skip template to
+include iff there is at least one registry configured to skip this validation.
+*/}}
+{{- define "skipDockerRegistryEnablingValidation" -}}
+{{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}true{{ end }}{{ end }}
+{{- end }}

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -93,7 +93,7 @@ data:
     $HAL_COMMAND config provider docker-registry enable {{ if (include "skipDockerRegistryEnablingValidation" .) -}} --no-validate {{- end }}
     {{- range $index, $registry := .Values.dockerRegistries }}
 
-    if $HAL_COMMAND config provider docker-registry account get {{ $registry.name }} {{ if $registry.noValidate -}} --no-validate {{- end }}; then
+    if $HAL_COMMAND config provider docker-registry account get {{ $registry.name }} {{- if $registry.noValidate }} --no-validate {{- end }}; then
       PROVIDER_COMMAND='edit'
     else
       PROVIDER_COMMAND='add'

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -90,9 +90,7 @@ data:
     {{ end }}
 
     # Docker Registry
-    {{ $skipValidation := false }}
-    {{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}{{ $skipValidation = true }}{{ end }}{{ end }}
-    $HAL_COMMAND config provider docker-registry enable {{ if $skipValidation -}} --no-validate {{- end }}
+    $HAL_COMMAND config provider docker-registry enable {{ if (include "skipDockerRegistryEnablingValidation" .) -}} --no-validate {{- end }}
     {{- range $index, $registry := .Values.dockerRegistries }}
 
     if $HAL_COMMAND config provider docker-registry account get {{ $registry.name }} {{ if $registry.noValidate -}} --no-validate {{- end }}; then

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -90,8 +90,8 @@ data:
     {{ end }}
 
     # Docker Registry
-    {{ $skipValidation := 0 }}
-    {{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}{{ $skipValidation = 1 }}{{ end }}{{ end }}
+    {{ $skipValidation := false }}
+    {{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}{{ $skipValidation = true }}{{ end }}{{ end }}
     $HAL_COMMAND config provider docker-registry enable {{ if $skipValidation -}} --no-validate {{- end }}
     {{- range $index, $registry := .Values.dockerRegistries }}
 

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -90,10 +90,12 @@ data:
     {{ end }}
 
     # Docker Registry
-    $HAL_COMMAND config provider docker-registry enable
+    {{ $skipValidation := 0 }}
+    {{ range $index, $registry := .Values.dockerRegistries }}{{ if $registry.noValidate }}{{ $skipValidation = 1 }}{{ end }}{{ end }}
+    $HAL_COMMAND config provider docker-registry enable {{ if $skipValidation -}} --no-validate {{- end }}
     {{- range $index, $registry := .Values.dockerRegistries }}
 
-    if $HAL_COMMAND config provider docker-registry account get {{ $registry.name }}; then
+    if $HAL_COMMAND config provider docker-registry account get {{ $registry.name }} {{ if $registry.noValidate -}} --no-validate {{- end }}; then
       PROVIDER_COMMAND='edit'
     else
       PROVIDER_COMMAND='add'


### PR DESCRIPTION
Adds the configurable `--no-validate` argument to all `hal config provider docker-registry` commands. The argument is also added to `hal config provider docker-registry enable` iff there is at least one registry configured to skip this validation step. 

Alternatively, we can do all Docker registry configuration in a separate script. However, then we will have to disable the call to `hal config provider docker-registry enable` in this chart when no registries are configured through `values.yaml`. Otherwise, it will do validation anyway of the registries configured on the targeted Halyard pod (which we try to circumvent here).   