### PR TITLE
PSM-1498 Add support for using an existing K8s secret for S3

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-2
+version: 2.2.12-picnic-3
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -67,7 +67,7 @@ data:
       {{- if or .Values.s3.accessKey .Values.s3.accountSecret }}
       --access-key-id "$(cat /opt/s3/accessKey)" \
       {{- end }}
-      {{- if .Values.s3.secretKey }}
+      {{- if or .Values.s3.secretKey .Values.s3.accountSecret }}
       --secret-access-key \
       {{- end }}
       {{- range .Values.s3.extraArgs }}

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -50,7 +50,7 @@ data:
     $HAL_COMMAND config storage edit --type s3
     {{ end }}
     {{ if .Values.s3.enabled }}
-    {{- if .Values.s3.secretKey -}} cat /opt/s3/secretKey | {{- end }} $HAL_COMMAND config storage s3 edit \
+    {{- if or .Values.s3.secretKey .Values.s3.accountSecret -}} cat /opt/s3/secretKey | {{- end }} $HAL_COMMAND config storage s3 edit \
       --bucket {{ .Values.s3.bucket }} \
       {{- if .Values.s3.rootFolder }}
       --root-folder {{ .Values.s3.rootFolder }} \
@@ -64,7 +64,7 @@ data:
       {{- if .Values.s3.assumeRole }}
       --assume-role {{ .Values.s3.assumeRole }} \
       {{- end }}
-      {{- if .Values.s3.accessKey }}
+      {{- if or .Values.s3.accessKey .Values.s3.accountSecret }}
       --access-key-id "$(cat /opt/s3/accessKey)" \
       {{- end }}
       {{- if .Values.s3.secretKey }}

--- a/charts/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/charts/spinnaker/templates/hooks/install-using-hal.yaml
@@ -83,10 +83,14 @@ spec:
           secretName: {{ template "spinnaker.fullname" . }}-gcs
         {{- end }}
       {{- end }}
-      {{- if and .Values.s3.enabled .Values.s3.accessKey .Values.s3.secretKey }}
+      {{- if .Values.s3.enabled }}
       - name: s3-secrets
         secret:
+          {{- if .Values.s3.accountSecret }}
+          secretName: {{ .Values.s3.accountSecret }}
+          {{- else }}
           secretName: {{ template "spinnaker.fullname" .}}-s3
+          {{- end }}
       {{- end }}
       {{- if .Values.halyard.pullSecrets }}
       imagePullSecrets:
@@ -124,7 +128,7 @@ spec:
         - name: gcs-key
           mountPath: /opt/gcs
         {{- end }}
-        {{- if and .Values.s3.enabled .Values.s3.accessKey .Values.s3.secretKey }}
+        {{- if .Values.s3.enabled }}
         - name: s3-secrets
           mountPath: /opt/s3
         {{- end }}

--- a/charts/spinnaker/templates/hooks/install-using-hal.yaml
+++ b/charts/spinnaker/templates/hooks/install-using-hal.yaml
@@ -83,7 +83,7 @@ spec:
           secretName: {{ template "spinnaker.fullname" . }}-gcs
         {{- end }}
       {{- end }}
-      {{- if .Values.s3.enabled }}
+      {{- if or .Values.s3.accountSecret (and .Values.s3.accessKey .Values.s3.secretKey) }}
       - name: s3-secrets
         secret:
           {{- if .Values.s3.accountSecret }}
@@ -128,7 +128,7 @@ spec:
         - name: gcs-key
           mountPath: /opt/gcs
         {{- end }}
-        {{- if .Values.s3.enabled }}
+        {{- if or .Values.s3.accountSecret (and .Values.s3.accessKey .Values.s3.secretKey) }}
         - name: s3-secrets
           mountPath: /opt/s3
         {{- end }}

--- a/charts/spinnaker/templates/statefulsets/halyard.yaml
+++ b/charts/spinnaker/templates/statefulsets/halyard.yaml
@@ -98,7 +98,7 @@ spec:
           {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-registry
           {{- end }}
-      {{- if .Values.s3.enabled }}
+      {{- if or .Values.s3.accountSecret (and .Values.s3.accessKey .Values.s3.secretKey) }}
       - name: s3-secrets
         secret:
           {{- if .Values.s3.accountSecret }}
@@ -175,7 +175,7 @@ spec:
         - name: gcs-key
           mountPath: /opt/gcs
         {{- end }}
-        {{- if .Values.s3.enabled }}
+        {{- if or .Values.s3.accountSecret (and .Values.s3.accessKey .Values.s3.secretKey) }}
         - name: s3-secrets
           mountPath: /opt/s3
         {{- end }}

--- a/charts/spinnaker/templates/statefulsets/halyard.yaml
+++ b/charts/spinnaker/templates/statefulsets/halyard.yaml
@@ -98,10 +98,14 @@ spec:
           {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-registry
           {{- end }}
-      {{- if and .Values.s3.enabled .Values.s3.accessKey .Values.s3.secretKey }}
+      {{- if .Values.s3.enabled }}
       - name: s3-secrets
         secret:
+          {{- if .Values.s3.accountSecret }}
+          secretName: {{ .Values.s3.accountSecret }}
+          {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-s3
+          {{- end }}
       {{- end }}
       {{- if or .Values.halyard.additionalSecrets.create (hasKey .Values.halyard.additionalSecrets "name") }}
       - name: additional-secrets
@@ -171,7 +175,7 @@ spec:
         - name: gcs-key
           mountPath: /opt/gcs
         {{- end }}
-        {{- if and .Values.s3.enabled .Values.s3.accessKey .Values.s3.secretKey }}
+        {{- if .Values.s3.enabled }}
         - name: s3-secrets
           mountPath: /opt/s3
         {{- end }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -316,7 +316,7 @@ s3:
   # endpoint: ""
   # accessKey: ""
   # secretKey: ""
-  ## Use an existing K8s secret containing an `accessKey` and `secretKey`.
+  ## Use an existing kubernetes secret containing an `accessKey` and `secretKey`.
   # accountSecret: ""
   # assumeRole: "<role to assume>"
   ## Here you can pass extra arguments to configure s3 storage options

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -316,6 +316,8 @@ s3:
   # endpoint: ""
   # accessKey: ""
   # secretKey: ""
+  ## Use an existing K8s secret containing an `accessKey` and `secretKey`.
+  # accountSecret: ""
   # assumeRole: "<role to assume>"
   ## Here you can pass extra arguments to configure s3 storage options
   extraArgs: []


### PR DESCRIPTION
Adds support for using an existing K8s secret to configure Spinnaker's S3 integration. This secret should contain a `accessKey` and `secretKey` for the AccessKeyID and SecretAccessKey respectively.   

Assumptions made:

- One always needs to configure credentials. Either through the existing two Helm values or through this new K8s secret. Templated if-statements are configured accordingly.
- The [native support](https://spinnaker.io/docs/reference/halyard/secrets/) of Halyard for (S3) secrets does not apply to the S3 configuration as it can not authenticate yet.

@nathankooij, you also had the idea of provisioning the secret instead of using one that is configured manually. How does that work? Could that be part of this Helm chart?

Also notice, I stayed consistent with the naming of `dockerRegistryAccountSecret` but did place it under `.s3`. Alternatively, we can create a `s3AccountSecret` in root. 

Suggested commit message:

```
Add support for using an existing K8s secret for S3 configuration (#3)
```
