### PR TITLE
PSM-1499 Add support for using an existing K8s secret for Redis configuration

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-3
+version: 2.2.12-picnic-4
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/_helpers.tpl
+++ b/charts/spinnaker/templates/_helpers.tpl
@@ -62,14 +62,18 @@ Create comma separated list of omitted namespaces in Kubernetes
 Redis base URL for Spinnaker
 */}}
 {{- define "spinnaker.redisBaseURL" -}}
-{{- if and .Values.redis.enabled .Values.redis.password }}
+{{- if .Values.redis.enabled }}
+{{- if .Values.redis.password }}
 {{- printf "redis://:%s@%s-redis-master:6379" .Values.redis.password .Release.Name -}}
-{{- else if .Values.redis.external.host }}
-{{- if .Values.redis.external.password }}
+{{- else if .Values.redis.auth.existingSecret }}
+{{- printf "redis://:$(cat /opt/redis/redis-password)@%s-redis-master:6379" .Release.Name -}}
+{{- end }}
+{{- else if .Values.redis.external.password }}
 {{- printf "redis://:%s@%s:%s" .Values.redis.external.password .Values.redis.external.host (.Values.redis.external.port | toString) -}}
+{{- else if .Values.redis.auth.existingSecret }}
+{{- printf "redis://:$(cat /opt/redis/redis-password)@%s:%s" .Values.redis.external.host (.Values.redis.external.port | toString) -}}
 {{- else }}
 {{- printf "redis://%s:%s" .Values.redis.external.host (.Values.redis.external.port | toString) -}}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/spinnaker/templates/_helpers.tpl
+++ b/charts/spinnaker/templates/_helpers.tpl
@@ -62,12 +62,14 @@ Create comma separated list of omitted namespaces in Kubernetes
 Redis base URL for Spinnaker
 */}}
 {{- define "spinnaker.redisBaseURL" -}}
-{{- if .Values.redis.enabled }}
+{{- if and .Values.redis.enabled .Values.redis.password }}
 {{- printf "redis://:%s@%s-redis-master:6379" .Values.redis.password .Release.Name -}}
-{{- else if .Values.redis.external.password }}
+{{- else if .Values.redis.external.host }}
+{{- if .Values.redis.external.password }}
 {{- printf "redis://:%s@%s:%s" .Values.redis.external.password .Values.redis.external.host (.Values.redis.external.port | toString) -}}
 {{- else }}
 {{- printf "redis://%s:%s" .Values.redis.external.host (.Values.redis.external.port | toString) -}}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -15,9 +15,7 @@ data:
     # Use Redis deployed via the dependent Helm chart
     rm -rf /tmp/spinnaker/.hal/default/service-settings
     mkdir -p /tmp/spinnaker/.hal/default/service-settings
-    {{- if .Values.redis.auth.existingSecret }}
-    echo "overrideBaseUrl: redis://$(cat /opt/redis/redis-password)@{{ .Release.Name }}-redis-master:6379" >> /tmp/service-settings/redis.yml
-    {{- end }}
+    echo "overrideBaseUrl: {{ include "spinnaker.redisBaseURL" . }}" >> /tmp/service-settings/redis.yml
     cp /tmp/service-settings/* /tmp/spinnaker/.hal/default/service-settings/
 
     rm -rf /tmp/spinnaker/.hal/default/profiles

--- a/charts/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -15,6 +15,9 @@ data:
     # Use Redis deployed via the dependent Helm chart
     rm -rf /tmp/spinnaker/.hal/default/service-settings
     mkdir -p /tmp/spinnaker/.hal/default/service-settings
+    {{- if .Values.redis.auth.existingSecret }}
+    echo "overrideBaseUrl: redis://$(cat /opt/redis/redis-password)@{{ .Release.Name }}-redis-master:6379" >> /tmp/service-settings/redis.yml
+    {{- end }}
     cp /tmp/service-settings/* /tmp/spinnaker/.hal/default/service-settings/
 
     rm -rf /tmp/spinnaker/.hal/default/profiles

--- a/charts/spinnaker/templates/configmap/service-settings.yaml
+++ b/charts/spinnaker/templates/configmap/service-settings.yaml
@@ -14,7 +14,9 @@ Render settings for each service by merging predefined defaults with values pass
 {{- /* Defaults: redis service */}}
 {{- $redisDefaults := dict -}}
 {{- $_ := set $redisDefaults "skipLifeCycleManagement" true -}}
+{{- if not .Values.redis.auth.existingSecret }}
 {{- $_ := set $redisDefaults "overrideBaseUrl" (include "spinnaker.redisBaseURL" $) -}}
+{{- end }}
 {{- $_ := set $settings "redis.yml" $redisDefaults -}}
 
 {{/* Defaults: gate service */}}

--- a/charts/spinnaker/templates/configmap/service-settings.yaml
+++ b/charts/spinnaker/templates/configmap/service-settings.yaml
@@ -14,9 +14,6 @@ Render settings for each service by merging predefined defaults with values pass
 {{- /* Defaults: redis service */}}
 {{- $redisDefaults := dict -}}
 {{- $_ := set $redisDefaults "skipLifeCycleManagement" true -}}
-{{- if not .Values.redis.auth.existingSecret }}
-{{- $_ := set $redisDefaults "overrideBaseUrl" (include "spinnaker.redisBaseURL" $) -}}
-{{- end }}
 {{- $_ := set $settings "redis.yml" $redisDefaults -}}
 
 {{/* Defaults: gate service */}}

--- a/charts/spinnaker/templates/statefulsets/halyard.yaml
+++ b/charts/spinnaker/templates/statefulsets/halyard.yaml
@@ -61,6 +61,10 @@ spec:
         - name: halyard-bom
           mountPath: /tmp/halyard-bom
         {{- end }}
+        {{- if .Values.redis.auth.existingSecret }}
+        - name: redis-secret
+          mountPath: /opt/redis
+        {{- end }}
         - name: halyard-initscript
           mountPath: /tmp/initscript
         {{- if .Values.halyard.customCerts.enabled }}
@@ -98,6 +102,11 @@ spec:
           {{- else }}
           secretName: {{ template "spinnaker.fullname" . }}-registry
           {{- end }}
+      {{- if .Values.redis.auth.existingSecret }}
+      - name: redis-secret
+        secret:
+          secretName: {{ .Values.redis.auth.existingSecret }}
+      {{- end }}
       {{- if or .Values.s3.accountSecret (and .Values.s3.accessKey .Values.s3.secretKey) }}
       - name: s3-secrets
         secret:


### PR DESCRIPTION
This one is significantly different than what we had with the 'pdsoels/fix-deployment' [branch](https://github.com/PicnicSupermarket/spinnaker-helm/compare/pdsoels/fix-deployment). In said branch, we mounted a secret containing the entire `redis.yml` with the password in the baseURL which we manually constructed from the, created by Redis chart, `spinnaker-redis` secret.

Here, instead, we reuse the existing value `redis.auth.existingSecret` which allows one to reference an existing K8s secret to setup the Redis cluster with. In this Spinnaker chart, we reuse it by mounting it to the initContainer of the main `Halyard` pod. This initContainer runs the `init.sh` script in which we can modify the `redis.yml` file by appending the baseURL containing the password which got retrieved through a file in the mounted secret. Kubernetes will automatically decode the file. 

As this is a different setup, we might need to test this out against our cluster. Furthermore, deleting the `halyard` pod is required.  

Strictly speaking the changes to the `_helper.tpl` is not necessary as we already have a surrounding `if` on its usage. But it felt nice to be explicit of the situation in which this baseURL is statically constructed.  

---

Suggested commit message:

```
Support reading an existing K8s secret for Redis configuration (#4)
```