### PR TITLE
PSM-1543 Fix Redis baseURL configuration

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-4
+version: 2.2.12-picnic-5
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-init-script.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-init-script.yaml
@@ -15,8 +15,8 @@ data:
     # Use Redis deployed via the dependent Helm chart
     rm -rf /tmp/spinnaker/.hal/default/service-settings
     mkdir -p /tmp/spinnaker/.hal/default/service-settings
-    echo "overrideBaseUrl: {{ include "spinnaker.redisBaseURL" . }}" >> /tmp/service-settings/redis.yml
     cp /tmp/service-settings/* /tmp/spinnaker/.hal/default/service-settings/
+    echo "overrideBaseUrl: {{ include "spinnaker.redisBaseURL" . }}" >> /tmp/spinnaker/.hal/default/service-settings/redis.yml
 
     rm -rf /tmp/spinnaker/.hal/default/profiles
     mkdir -p /tmp/spinnaker/.hal/default/profiles

--- a/charts/spinnaker/templates/configmap/service-settings.yaml
+++ b/charts/spinnaker/templates/configmap/service-settings.yaml
@@ -39,7 +39,7 @@ Render settings for each service by merging predefined defaults with values pass
 {{- /* Convert the content of settings key to YAML string */}}
 {{- range $filename, $content := $settings -}}
 {{- if not (typeIs "string" $content) -}}
-{{- $_ := set $settings $filename ($content | toYaml) -}}
+{{- $_ := set $settings $filename (printf "%s\n" ($content | toYaml)) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
During our deployment we noticed that the commit shipped with tag https://github.com/PicnicSupermarket/spinnaker-helm/releases/tag/spinnaker-2.2.12-picnic-4 introduces two bugs:

1. We can not write to the file as was configured as we got a permission denied. Even with greater permissions (666), the system returned that the filesystem was reaodnly. 
2. We can not simply append a string to the `redis.yml` file as the file does not end with a newline. The generated YAML in the `service-settings` ConfigMap chomps off newlines (i.e. `redis.yaml: |-`).

For (1), we now write to the target files after the copy command, which we are allowed to do.
For (2), we now suffix a newline to the generated yaml files before passing it to the final `toYaml` function. As indicated in [this SO thread](https://stackoverflow.com/a/62348268), if the passed data ends with a newline, a YAML definition preserving this newline will be created (i.e. `redis: |` from the previous example).   

Suggested commit message:

```
Fix Redis `overrideBaseUrl` configuration permissions and newline issues (#5)

By making sure the resulting YAML files are ending with a newline and by
writing to a file for which the pod has permissions to write to. Fixes the bug 
as introduced in 
https://github.com/PicnicSupermarket/spinnaker-helm/commit/d8a27290ae74b820c0414abd846e73a042f36c61.
```