### PR TITLE
Create Spinnaker account per context and namespace combination

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-5
+version: 2.2.12-picnic-6
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/README.md
+++ b/charts/spinnaker/README.md
@@ -57,8 +57,8 @@ kubeConfig:
   contexts:
   # Names of contexts available in the uploaded kubeconfig
   - my-context
-  # This is the Spinnaker account that you would like to use to
-  # deploy Spinnaker itself with.
+  # The Spinnaker account that you would like to use to deploy Spinnaker itself
+  # with.
   deploymentAccount: my-context
 ```
 
@@ -81,8 +81,8 @@ kubeConfig:
   contexts:
   # Names of contexts available in the uploaded kubeconfig
   - my-context
-  # This is the Spinnaker account that you would like to use to
-  # deploy Spinnaker itself with.
+  # The Spinnaker account that you would like to use to deploy Spinnaker itself
+  # with.
   deploymentAccount: my-context
 ```
 

--- a/charts/spinnaker/README.md
+++ b/charts/spinnaker/README.md
@@ -57,9 +57,9 @@ kubeConfig:
   contexts:
   # Names of contexts available in the uploaded kubeconfig
   - my-context
-  # This is the context from the list above that you would like
-  # to deploy Spinnaker itself to.
-  deploymentContext: my-context
+  # This is the Spinnaker account that you would like to use to
+  # deploy Spinnaker itself with.
+  deploymentAccount: my-context
 ```
 
 ### Configuring arbitrary clusters with s3
@@ -81,9 +81,9 @@ kubeConfig:
   contexts:
   # Names of contexts available in the uploaded kubeconfig
   - my-context
-  # This is the context from the list above that you would like
-  # to deploy Spinnaker itself to.
-  deploymentContext: my-context
+  # This is the Spinnaker account that you would like to use to
+  # deploy Spinnaker itself with.
+  deploymentAccount: my-context
 ```
 
 ## Specifying Docker Registries and Valid Images (Repositories)

--- a/charts/spinnaker/README.md
+++ b/charts/spinnaker/README.md
@@ -56,10 +56,10 @@ kubeConfig:
   secretKey: config
   contexts:
   # Names of contexts available in the uploaded kubeconfig
-  - my-context
+  - production
   # The Spinnaker account that you would like to use to deploy Spinnaker itself
   # with.
-  deploymentAccount: my-context
+  deploymentAccount: production
 ```
 
 ### Configuring arbitrary clusters with s3
@@ -80,10 +80,10 @@ kubeConfig:
   encryptedKubeconfig: encrypted:s3!r:us-west-2!b:mybucket!f:mykubeconfig
   contexts:
   # Names of contexts available in the uploaded kubeconfig
-  - my-context
+  - production
   # The Spinnaker account that you would like to use to deploy Spinnaker itself
   # with.
-  deploymentAccount: my-context
+  deploymentAccount: production
 ```
 
 ## Specifying Docker Registries and Valid Images (Repositories)

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -109,6 +109,7 @@ data:
     {{- end }}
 
     $HAL_COMMAND config provider kubernetes enable
+    {{- if $.Values.kubeConfig.accountPerContext }}
     {{- range $index, $context := .Values.kubeConfig.contexts }}
 
     if $HAL_COMMAND config provider kubernetes account get {{ $context }}; then
@@ -129,7 +130,29 @@ data:
                 {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
                 --provider-version v2
     {{- end }}
-    $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentContext }} --type distributed \
+    {{- end }}
+
+    {{- if $.Values.kubeConfig.accountPerContextAndNamespace }}
+    {{- range $context := .Values.kubeConfig.contexts }}
+    {{- range $namespacedAccount := $.Values.kubeConfig.namespacedAccounts }}
+    {{- $accountName := printf "%s.%s" $context $namespacedAccount.namespace }}
+    
+    if $HAL_COMMAND config provider kubernetes account get {{ $accountName }}; then
+      PROVIDER_COMMAND='edit'
+    else
+      PROVIDER_COMMAND='add'
+    fi
+
+    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $accountName }} --docker-registries dockerhub \
+                --context {{ $context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
+                {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
+                {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
+                --namespaces={{ $namespacedAccount.namespace }} \
+                --provider-version v2
+    {{- end }}
+    {{- end }}
+    {{- end }}
+    $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentAccount }} --type distributed \
                            --location {{ .Release.Namespace }}
     # Use Deck to route to Gate
     $HAL_COMMAND config security api edit --no-validate --override-base-url /gate

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -109,7 +109,7 @@ data:
     {{- end }}
 
     $HAL_COMMAND config provider kubernetes enable
-    {{- if $.Values.kubeConfig.accountPerContext }}
+    {{- if .Values.kubeConfig.accountPerContext }}
     {{- range $index, $context := .Values.kubeConfig.contexts }}
 
     if $HAL_COMMAND config provider kubernetes account get {{ $context }}; then
@@ -132,9 +132,9 @@ data:
     {{- end }}
     {{- end }}
 
-    {{- if $.Values.kubeConfig.accountPerContextAndNamespace }}
+    {{- if .Values.kubeConfig.accountPerContextAndNamespace }}
     {{- range $context := .Values.kubeConfig.contexts }}
-    {{- range $namespacedAccount := $.Values.kubeConfig.namespacedAccounts }}
+    {{- range $namespacedAccount := $.Values.kubeConfig.namespacePartitionedAccounts }}
     {{- $accountName := printf "%s.%s" $context $namespacedAccount.namespace }}
     
     if $HAL_COMMAND config provider kubernetes account get {{ $accountName }}; then

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -170,6 +170,14 @@ kubeConfig:
   # Use this when you want to register arbitrary clusters with Spinnaker
   # Upload your ~/kube/.config to a secret
   enabled: false
+  # Creates a Spinnaker account per context in `.kubeConfig.contexts` with the
+  # same name. Can be used together with
+  # `.kubeConfig.accountPerContextAndNamespace`.
+  accountPerContext: true
+  # Creates a Spinnaker account for each combination of context and namespace
+  # as per `.kubeConfig.contexts` and `.kubeConfig.namespacedAccounts`. Can be
+  # used together with `.kubeConfig.accountPerContext`.
+  accountPerContextAndNamespace: false
   # secretName: my-kubeconfig
   # secretKey: config
   # Use this when you want to configure halyard to reference a kubeconfig from s3
@@ -180,7 +188,8 @@ kubeConfig:
   # List of contexts from the kubeconfig to make available to Spinnaker
   contexts:
   - default
-  deploymentContext: default
+  # The Spinnaker account that will be used to deploy the Spinnaker cluster to.
+  deploymentAccount: default
   # Use this to limit the namespaces this kubernetes account will access.
   # Note, if you use nameSpaces, omittedNameSpaces will not be used.
   # Note, the casing of the nameSpace variable here.
@@ -192,6 +201,12 @@ kubeConfig:
   - kube-public
   onlySpinnakerManaged:
     enabled: false
+  # A list of per-namespace account-related configuration. For the purpose of
+  # this chart, this only specifies the `namespace`. But this can be extended
+  # for own Helm templating to further configure Spinnaker (e.g. assigning
+  # permissions to the accounts).
+  namespacedAccounts:
+    - namespace: default
 
   # When false, clouddriver will skip the permission checks for all kubernetes kinds at startup.
   # This can save a great deal of time during clouddriver startup when you have many kubernetes

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -175,8 +175,8 @@ kubeConfig:
   # `.kubeConfig.accountPerContextAndNamespace`.
   accountPerContext: true
   # Creates a Spinnaker account for each combination of context and namespace
-  # as per `.kubeConfig.contexts` and `.kubeConfig.namespacedAccounts`. Can be
-  # used together with `.kubeConfig.accountPerContext`.
+  # as per `contexts` and `namespacePartitionedAccounts`. Can be used together
+  # with`accountPerContext`.
   accountPerContextAndNamespace: false
   # secretName: my-kubeconfig
   # secretKey: config
@@ -205,7 +205,7 @@ kubeConfig:
   # this chart, this only specifies the `namespace`. But this can be extended
   # for own Helm templating to further configure Spinnaker (e.g. assigning
   # permissions to the accounts).
-  namespacedAccounts:
+  namespacePartitionedAccounts:
     - namespace: default
 
   # When false, clouddriver will skip the permission checks for all kubernetes kinds at startup.


### PR DESCRIPTION
Suggested commit message:

```
Allow for Spinnaker account creation per context and namespace combination (#6)

In addition to the existing account-per-context functionality. Setting
`accountPerContextAndNamespace` to `true` and specifying the namespaces in
`namespacePartitionedAccounts` creates these accounts. Furthermore, rename
field `deploymentContext` to `deploymentAccount` to better reflect what it
refers to.
```