### PR TITLE
Create Spinnaker Kubernetes accounts explicitly

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-6
+version: 2.2.12-picnic-7
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/README.md
+++ b/charts/spinnaker/README.md
@@ -54,9 +54,10 @@ kubeConfig:
   enabled: true
   secretName: my-kubeconfig
   secretKey: config
-  contexts:
-  # Names of contexts available in the uploaded kubeconfig
-  - production
+  accounts:
+    production:
+       # Context available in the uploaded kubeconfig
+       context: production
   # The Spinnaker account that you would like to use to deploy Spinnaker itself
   # with.
   deploymentAccount: production
@@ -78,9 +79,10 @@ kubeConfig:
   # secretName: my-kubeconfig
   # secretKey: config
   encryptedKubeconfig: encrypted:s3!r:us-west-2!b:mybucket!f:mykubeconfig
-  contexts:
-  # Names of contexts available in the uploaded kubeconfig
-  - production
+  accounts:
+    production:
+       # Context available in the uploaded kubeconfig
+       context: production
   # The Spinnaker account that you would like to use to deploy Spinnaker itself
   # with.
   deploymentAccount: production

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -128,7 +128,7 @@ data:
                 {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
                 {{ if $account.readPermissions }}--read-permissions {{ join "," $account.readPermissions }}{{ end }} \
-                {{ if $account.writePermissions }}--write-permissions {{ join "," $values.writePermissions }}{{ end }} \
+                {{ if $account.writePermissions }}--write-permissions {{ join "," $account.writePermissions }}{{ end }} \
                 --provider-version v2
     {{- end }}
 

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -109,7 +109,7 @@ data:
     {{- end }}
 
     $HAL_COMMAND config provider kubernetes enable
-    {{- range $accountName, $values := .Values.kubeConfig.accounts }}
+    {{- range $accountName, $account := .Values.kubeConfig.accounts }}
 
     if $HAL_COMMAND config provider kubernetes account get {{ $accountName }}; then
       PROVIDER_COMMAND='edit'
@@ -118,17 +118,17 @@ data:
     fi
 
     $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $accountName }} --docker-registries dockerhub \
-                --context {{ $values.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
+                --context {{ $account.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
                 {{ if not $.Values.kubeConfig.checkPermissionsOnStartup }}--check-permissions-on-startup false{{ end }} \
-                {{ if $values.namespaces }}--namespaces={{ join "," $values.namespaces }}{{ end }} \
-                {{ if not $values.namespaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
+                {{ if $account.namespaces }}--namespaces={{ join "," $account.namespaces }}{{ end }} \
+                {{ if not $account.namespaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
-                {{ if $values.readPermissions }}--read-permissions {{ join "," $values.readPermissions }}{{ end }} \
-                {{ if $values.writePermissions }}--write-permissions {{ join "," $values.writePermissions }}{{ end }} \
+                {{ if $account.readPermissions }}--read-permissions {{ join "," $account.readPermissions }}{{ end }} \
+                {{ if $account.writePermissions }}--write-permissions {{ join "," $values.writePermissions }}{{ end }} \
                 --provider-version v2
     {{- end }}
 

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -109,34 +109,8 @@ data:
     {{- end }}
 
     $HAL_COMMAND config provider kubernetes enable
-    {{- if .Values.kubeConfig.accountPerContext }}
-    {{- range $index, $context := .Values.kubeConfig.contexts }}
+    {{- range $accountName, $values := .Values.kubeConfig.accounts }}
 
-    if $HAL_COMMAND config provider kubernetes account get {{ $context }}; then
-      PROVIDER_COMMAND='edit'
-    else
-      PROVIDER_COMMAND='add'
-    fi
-
-    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $context }} --docker-registries dockerhub \
-                --context {{ $context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
-                {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
-                {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
-                {{ if not $.Values.kubeConfig.checkPermissionsOnStartup }}--check-permissions-on-startup false{{ end }} \
-                {{ if $.Values.kubeConfig.nameSpaces }}--namespaces={{ template "nameSpaces" $ }}{{ end }} \
-                {{ if not $.Values.kubeConfig.nameSpaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
-                {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
-                {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
-                {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
-                --provider-version v2
-    {{- end }}
-    {{- end }}
-
-    {{- if .Values.kubeConfig.accountPerContextAndNamespace }}
-    {{- range $context := .Values.kubeConfig.contexts }}
-    {{- range $namespacedAccount := $.Values.kubeConfig.namespacePartitionedAccounts }}
-    {{- $accountName := printf "%s.%s" $context $namespacedAccount.namespace }}
-    
     if $HAL_COMMAND config provider kubernetes account get {{ $accountName }}; then
       PROVIDER_COMMAND='edit'
     else
@@ -144,14 +118,20 @@ data:
     fi
 
     $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $accountName }} --docker-registries dockerhub \
-                --context {{ $context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
+                --context {{ $values.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
-                --namespaces={{ $namespacedAccount.namespace }} \
+                {{ if not $.Values.kubeConfig.checkPermissionsOnStartup }}--check-permissions-on-startup false{{ end }} \
+                {{ if $values.namespaces }}--namespaces={{ join "," $values.namespaces }}{{ end }} \
+                {{ if not $values.namespaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
+                {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
+                {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
+                {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
+                {{ if $values.readPermissions }}--read-permissions {{ join "," $values.readPermissions }}{{ end }} \
+                {{ if $values.writePermissions }}--write-permissions {{ join "," $values.writePermissions }}{{ end }} \
                 --provider-version v2
     {{- end }}
-    {{- end }}
-    {{- end }}
+
     $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentAccount }} --type distributed \
                            --location {{ .Release.Namespace }}
     # Use Deck to route to Gate

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -109,21 +109,23 @@ data:
     {{- end }}
 
     $HAL_COMMAND config provider kubernetes enable
-    {{- range $accountName, $account := .Values.kubeConfig.accounts }}
+    {{- range $name, $account := .Values.kubeConfig.accounts }}
 
-    if $HAL_COMMAND config provider kubernetes account get {{ $accountName }}; then
+    if $HAL_COMMAND config provider kubernetes account get {{ $name }}; then
       PROVIDER_COMMAND='edit'
     else
       PROVIDER_COMMAND='add'
     fi
 
-    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $accountName }} --docker-registries dockerhub \
+    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
                 --context {{ $account.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
                 {{ if not $.Values.kubeConfig.checkPermissionsOnStartup }}--check-permissions-on-startup false{{ end }} \
                 {{ if $account.namespaces }}--namespaces={{ join "," $account.namespaces }}{{ end }} \
-                {{ if not $account.namespaces }}--omit-namespaces={{ template "omittedNameSpaces" $ }}{{ end }} \
+                {{ if not $account.namespaces }}--omit-namespaces=
+                  {{- join "," (ternary $.Values.kubeConfig.omittedNameSpaces $account.omittedNamespaces (not $account.omittedNamespaces)) -}}
+                {{ end }} \
                 {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -181,10 +181,18 @@ kubeConfig:
     # default:
       # context: default
       # Use this to limit the namespaces this kubernetes account will access.
-      # Note, if you use `namespaces`, global `omittedNameSpaces` will not be used.
+      # Note, if you use `namespaces`, account-specific nor global
+      # `omittedNameSpaces` will be used.
       # namespaces:
       #   - namespace1
       #   - namespace2
+      # The namespaces not to include for this account. Has preference over
+      # globally configured `omittedNameSpaces`. Will not be used when account-
+      # specific namespaces are configured.
+      # omittedNamespaces:
+      #   - kube-system
+      #   - kube-public
+      #   - namespace3
       # Use this to limit the Spinnaker RBAC roles than can read from Kubernetes.
       # readPermissions:
       #   - role1
@@ -195,6 +203,8 @@ kubeConfig:
       #   - role2
   # The Spinnaker account that will be used to deploy the Spinnaker cluster to.
   deploymentAccount: default
+  # The namespaces not to include for all accounts. Will not be used when
+  # account-specific namespaces or omitted namespaces are configured.
   omittedNameSpaces:
   - kube-system
   - kube-public

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -170,14 +170,6 @@ kubeConfig:
   # Use this when you want to register arbitrary clusters with Spinnaker
   # Upload your ~/kube/.config to a secret
   enabled: false
-  # Creates a Spinnaker account per context in `.kubeConfig.contexts` with the
-  # same name. Can be used together with
-  # `.kubeConfig.accountPerContextAndNamespace`.
-  accountPerContext: true
-  # Creates a Spinnaker account for each combination of context and namespace
-  # as per `contexts` and `namespacePartitionedAccounts`. Can be used together
-  # with`accountPerContext`.
-  accountPerContextAndNamespace: false
   # secretName: my-kubeconfig
   # secretKey: config
   # Use this when you want to configure halyard to reference a kubeconfig from s3
@@ -185,28 +177,29 @@ kubeConfig:
   # For more info visit:
   #   https://www.spinnaker.io/reference/halyard/secrets/s3-secrets/#secrets-in-s3
   # encryptedKubeconfig: encrypted:s3!r:us-west-2!b:mybucket!f:mykubeconfig
-  # List of contexts from the kubeconfig to make available to Spinnaker
-  contexts:
-  - default
+  accounts:
+    # default:
+      # context: default
+      # Use this to limit the namespaces this kubernetes account will access.
+      # Note, if you use `namespaces`, global `omittedNameSpaces` will not be used.
+      # namespaces:
+      #   - namespace1
+      #   - namespace2
+      # Use this to limit the Spinnaker RBAC roles than can read from Kubernetes.
+      # readPermissions:
+      #   - role1
+      #   - role2
+      # Use this to limit the Spinnaker RBAC roles than can write (i.e. Deploy) to Kubernetes.
+      # writePermissions:
+      #   - role1
+      #   - role2
   # The Spinnaker account that will be used to deploy the Spinnaker cluster to.
   deploymentAccount: default
-  # Use this to limit the namespaces this kubernetes account will access.
-  # Note, if you use nameSpaces, omittedNameSpaces will not be used.
-  # Note, the casing of the nameSpace variable here.
-  # nameSpaces:
-  # - namespace1
-  # - namespace2
   omittedNameSpaces:
   - kube-system
   - kube-public
   onlySpinnakerManaged:
     enabled: false
-  # A list of per-namespace account-related configuration. For the purpose of
-  # this chart, this only specifies the `namespace`. But this can be extended
-  # for own Helm templating to further configure Spinnaker (e.g. assigning
-  # permissions to the accounts).
-  namespacePartitionedAccounts:
-    - namespace: default
 
   # When false, clouddriver will skip the permission checks for all kubernetes kinds at startup.
   # This can save a great deal of time during clouddriver startup when you have many kubernetes


### PR DESCRIPTION
Changes the Helm chart in a non-backwards-compatible way to have greater control over the way that Spinnaker accounts for interacting with Kubernetes are created. 

The previous implementation had the limitation that we could not control the account name and instead had a 1-to-1 correlation with the context. As internally we have a 1-to-1 correlation between context and cluster, and want to have accounts with distinctive namespaces, we can not easily create differently-named accounts to achieve this distinction.

An earlier change in https://github.com/PicnicSupermarket/spinnaker-helm/pull/6 was a first attempt to achieve this namespace-based distinction, but was rather Picnic opinionated. Instead, this implementation is resolved of any bias and gives full control over the account creation with its name, context, namespaces.

Additionally, I have added the possibility to specify which `readPermissions` and `writePermissions` should be configured for these accounts. Only uncertainty here is whether this works for clean installs of the Spinnaker cluster and whether these roles are then available or not.

Suggested commit message:

```
Create Spinnaker Kubernetes accounts explicitly (#7)

As opposed to creating an account for each cluster. This provides greater
control over the naming of the account and the namespaces the account has
access to.

While there, introduce `readPermissions` and `writePermissions` per created
account to control the Spinnaker RBAC roles that can interact with these
accounts.
```

I chose not to update the README too much (apart from making it correct) given that we have not written the majority of it and as such it might not fully apply to our case.