### PR TITLE
Fix configuration of read and write permissions for multiple roles

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-7
+version: 2.2.12-picnic-8
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -129,8 +129,8 @@ data:
                 {{ if $.Values.kubeConfig.omittedKinds }}--omit-kinds={{ template "omittedKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.kinds }}--kinds={{ template "k8sKinds" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.liveManifestCalls }}--live-manifest-calls true{{ end }} \
-                {{ if $account.readPermissions }}--read-permissions {{ join "," $account.readPermissions }}{{ end }} \
-                {{ if $account.writePermissions }}--write-permissions {{ join "," $account.writePermissions }}{{ end }} \
+                {{ if $account.readPermissions }}--read-permissions {{ join " --read-permissions " $account.readPermissions }}{{ end }} \
+                {{ if $account.writePermissions }}--write-permissions {{ join " --write-permissions " $account.writePermissions }}{{ end }} \
                 --provider-version v2
     {{- end }}
 


### PR DESCRIPTION
```
Fix configuration of read and write permissions for multiple roles (#8)
```

Double checked `namespaces`, that one still works as expected.

Relevant Helm(file) diff (anonimized):

```diff
      $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND accountName \
                  --context my-context  \
                  --namespaces=namespace1,namespace2 \
-                 --read-permissions role1,role2 \
-                 --write-permissions role1,role2 \
+                 --read-permissions role1 --read-permissions role2 \
+                 --write-permissions role1 --write-permissions role2 \
                  --provider-version v2

```

Relevant Hal config change (anonimized):

```diff
      - name: account-name
        permissions:
          READ:
-         - 'role1,role2'
+ 		  - role1
+         - role2
          WRITE:
-         - 'role1,role2'
+ 		  - role1
+         - role2
        context: my-context
        namespaces:
        - namespace1
        - namespace2
```