### PR TITLE
Modify Kubernetes accounts in parallel

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-8
+version: 2.2.12-picnic-9
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -111,13 +111,14 @@ data:
     $HAL_COMMAND config provider kubernetes enable
     {{- range $name, $account := .Values.kubeConfig.accounts }}
 
+    cat > /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }} <<- EOF
     if $HAL_COMMAND config provider kubernetes account get {{ $name }}; then
       PROVIDER_COMMAND='edit'
     else
       PROVIDER_COMMAND='add'
     fi
 
-    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
+    $HAL_COMMAND config provider kubernetes account \$PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
                 --context {{ $account.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
@@ -132,7 +133,15 @@ data:
                 {{ if $account.readPermissions }}--read-permissions {{ join " --read-permissions " $account.readPermissions }}{{ end }} \
                 {{ if $account.writePermissions }}--write-permissions {{ join " --write-permissions " $account.writePermissions }}{{ end }} \
                 --provider-version v2
+    EOF
     {{- end }}
+
+    # Run the commands in parallel over the account names limited by the specified parallelism factor.
+    xargs -P {{ .Values.halyard.installParallelism }} -I {} sh -c 'eval "$1"' - {} <<'EOF'
+    {{- range $name, $account := .Values.kubeConfig.accounts }}
+    source /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }}
+    {{- end }}
+    EOF
 
     $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentAccount }} --type distributed \
                            --location {{ .Release.Namespace }}

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -137,9 +137,9 @@ data:
     {{- end }}
 
     # Run the commands in parallel over the account names limited by the specified parallelism factor.
-    xargs -P {{ .Values.halyard.installParallelism }} -I {} sh -c 'eval "$1"' - {} <<'EOF'
+    xargs -P {{ .Values.halyard.installParallelism }} -I {} sh {} <<'EOF'
     {{- range $name, $account := .Values.kubeConfig.accounts }}
-    source /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }}
+    /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }}
     {{- end }}
     EOF
 

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -137,7 +137,7 @@ data:
     {{- end }}
 
     # Run the commands in parallel over the account names limited by the specified parallelism factor.
-    xargs -P {{ .Values.halyard.installParallelism }} -I {} sh {} <<'EOF'
+    xargs -P {{ .Values.halyard.installParallelism }} -n 1 sh <<'EOF'
     {{- range $name, $account := .Values.kubeConfig.accounts }}
     /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }}
     {{- end }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -130,6 +130,8 @@ halyard:
     ## Enable to override the default cacerts with your own one
     enabled: false
     secretName: custom-cacerts
+  # How many Kubernetes account commands are executed in parallel.
+  installParallelism: 8
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions


### PR DESCRIPTION
Of which the parallelism factor can be controlled via `halyard.installParallelism`.

Suggested commit message:

```
Modify Kubernetes accounts in parallel (#10)

Of which the parallelism factor can be controlled via
`halyard.installParallelism`.
```

Provides a hefty boost of more than 50% in prod. We can also tweak the parallelism factor further in the future.