### PR TITLE
Revert "Modify Kubernetes accounts in parallel (#10)"

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-9
+version: 2.2.12-picnic-8
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-8
+version: 2.2.12-picnic-10
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -111,14 +111,13 @@ data:
     $HAL_COMMAND config provider kubernetes enable
     {{- range $name, $account := .Values.kubeConfig.accounts }}
 
-    cat > /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }} <<- EOF
     if $HAL_COMMAND config provider kubernetes account get {{ $name }}; then
       PROVIDER_COMMAND='edit'
     else
       PROVIDER_COMMAND='add'
     fi
 
-    $HAL_COMMAND config provider kubernetes account \$PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
+    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
                 --context {{ $account.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \
@@ -133,15 +132,7 @@ data:
                 {{ if $account.readPermissions }}--read-permissions {{ join " --read-permissions " $account.readPermissions }}{{ end }} \
                 {{ if $account.writePermissions }}--write-permissions {{ join " --write-permissions " $account.writePermissions }}{{ end }} \
                 --provider-version v2
-    EOF
     {{- end }}
-
-    # Run the commands in parallel over the account names limited by the specified parallelism factor.
-    xargs -P {{ .Values.halyard.installParallelism }} -n 1 sh <<'EOF'
-    {{- range $name, $account := .Values.kubeConfig.accounts }}
-    /tmp/upsert_{{ regexReplaceAll "\\.|-" $name "_" }}
-    {{- end }}
-    EOF
 
     $HAL_COMMAND config deploy edit --account-name {{ .Values.kubeConfig.deploymentAccount }} --type distributed \
                            --location {{ .Release.Namespace }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -130,8 +130,6 @@ halyard:
     ## Enable to override the default cacerts with your own one
     enabled: false
     secretName: custom-cacerts
-  # How many Kubernetes account commands are executed in parallel.
-  installParallelism: 8
 
 # Define which registries and repositories you want available in your
 # Spinnaker pipeline definitions


### PR DESCRIPTION
Suggested commit message:

```
Revert "Modify Kubernetes accounts in parallel (#10)" (#11)

This reverts commit 0ed6fd442fc0e8bbf5f18bdea3414f4133c0ef42.

A regression was identified that parallel execution can lead to inconsistent
state due to Halyard not correctly handling concurrent requests.
```