### PR TITLE
PSM-2922 Introduce PDBs for Spinnaker HA services

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-11
+version: 2.2.12-picnic-12
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/poddisruptionbudget/pdb.yaml
+++ b/charts/spinnaker/templates/poddisruptionbudget/pdb.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.pdb.create }}
+{{- range .Values.pdb.services }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "spinnaker.fullname" $ }}-{{ . }}
+  labels:
+{{ include "spinnaker.standard-labels" $ | indent 4 }}
+spec:
+  {{- if $.Values.pdb.minAvailable }}
+  minAvailable: {{ $.Values.pdb.minAvailable }}
+  {{- end }}
+  {{- if $.Values.pdb.maxUnavailable }}
+  maxUnavailable: {{ $.Values.pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: {{ . }}
+      app.kubernetes.io/part-of: spinnaker
+{{- end }}
+{{- end }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -360,6 +360,28 @@ rbac:
   # Specifies whether PSP resources should be created
   pspEnabled: false
 
+pdb:
+  # Specifies whether a PodDisruptionBudget should be created
+  #
+  create: true
+  services:
+    - clouddriver
+    - deck
+    - echo-worker
+    - fiat
+    - front50
+    - gate
+    - igor
+    - rosco
+  # Min number or percentage of pods that must still be available after the
+  # eviction
+  #
+  minAvailable: 40%
+  # Max number of pods that can be unavailable after the eviction
+  #
+  maxUnavailable: ""
+
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -362,7 +362,6 @@ rbac:
 
 pdb:
   # Specifies whether a PodDisruptionBudget should be created
-  #
   create: true
   services:
     - clouddriver
@@ -375,10 +374,8 @@ pdb:
     - rosco
   # Min number or percentage of pods that must still be available after the
   # eviction
-  #
   minAvailable: 40%
   # Max number of pods that can be unavailable after the eviction
-  #
   maxUnavailable: ""
 
 


### PR DESCRIPTION
Suggested commit message:
```
PSM-2922 Introduce PDBs for Spinnaker HA services

By default, we require at least 40% of replicas to be available for each
individual Spinnaker component.
```
