### PR TITLE
INF-8817 Allow filtering Docker registries by regex

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-13
+version: 2.2.12-picnic-14
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -104,6 +104,7 @@ data:
       {{ if $registry.passwordCommand -}} --password-command "{{ $registry.passwordCommand }}"{{ else -}} --password-file /opt/registry/passwords/{{ $registry.name }}{{- end }} \
       {{ if $registry.email -}} --email {{ $registry.email }}{{- end -}}{{- end }} \
       {{ if $registry.noValidate -}} --no-validate {{- end }} \
+      {{ if $registry.repositoriesRegex -}} --repositories-regex '{{ $registry.repositoriesRegex }}' {{- end }} \
       {{ if $registry.repositories -}} --repositories {{ range $index, $repository := $registry.repositories }}{{if $index}},{{end}}{{- $repository }}{{- end }}{{- end }}
 
     {{- end }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -146,6 +146,7 @@ dockerRegistries:
 - name: dockerhub
   address: index.docker.io
   noValidate: false
+  repositoriesRegex: '^filtered-repository$'
   repositories:
     - library/alpine
     - library/ubuntu


### PR DESCRIPTION
Commit message:
```
INF-8817 Allow filtering Docker registries by regex
```

> Note: This option is not [documented ](https://spinnaker.io/docs/reference/halyard/commands/#usage-428), but it does [exist](https://github.com/spinnaker/halyard/blob/4b5c126cfd8fb3b8490649e1c515495acff51817/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryAddAccountCommand.java#L110) 🤷🏻 
