### PR TITLE
DPLA-979 Configure K8s Spinnaker accounts to use ECR registry instead of DockerHub

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12-picnic-15
+version: 2.2.12-picnic-16
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -136,7 +136,7 @@ data:
       PROVIDER_COMMAND='add'
     fi
 
-    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $name }} --docker-registries dockerhub \
+    $HAL_COMMAND config provider kubernetes account $PROVIDER_COMMAND {{ $name }} --docker-registries ecr \
                 --context {{ $account.context }} {{ if not $.Values.kubeConfig.enabled }}--service-account true{{ end }} \
                 {{ if $.Values.kubeConfig.enabled }}--kubeconfig-file {{ template "spinnaker.kubeconfig" $ }}{{ end }} \
                 {{ if $.Values.kubeConfig.onlySpinnakerManaged.enabled }}--only-spinnaker-managed true{{ end }} \


### PR DESCRIPTION
> What is this doing / Why has this not caused issues before?

I don't know, but it is incorrect nonetheless 😅. It will either be a no-op or improve things, but I would not expect it to worsen things. Also, it will make the `diff` less confusing for future `helmfile sync's`.

I don't feel spending the time to check is worth the time for this one. Let me know if you disagree.