### PR TITLE
INF-9106 Setup nodeAffinity for spinnaker components

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.12
+version: 2.2.13
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/statefulsets/halyard.yaml
+++ b/charts/spinnaker/templates/statefulsets/halyard.yaml
@@ -30,6 +30,9 @@ spec:
       securityContext:
         runAsUser: {{ .Values.securityContext.runAsUser }}
         fsGroup: {{ .Values.securityContext.fsGroup }}
+    {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -251,6 +251,11 @@ spinnakerFeatureFlags: []
 # nodeSelector to provide to each of the Spinnaker components
 nodeSelector: {}
 
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
+# Affinity to provide to each of the Spinnaker components
+affinity: {}
+
 # Node tolerations
 # Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/
 tolerations: []


### PR DESCRIPTION
We're migrating from Karpenter to castai to manage our nodes in K8s. In castai, there is a hard requirement to specify nodeAffinity labels beside tolerations. So, we need to add the ability to specify nodeAffinity.